### PR TITLE
nanosvg.h (nsvg__parseTransform): initialize the local float t[0]

### DIFF
--- a/src/nanosvg.h
+++ b/src/nanosvg.h
@@ -1653,7 +1653,7 @@ static int nsvg__parseRotate(float* xform, const char* str)
 
 static void nsvg__parseTransform(float* xform, const char* str)
 {
-	float t[6];
+	float t[6] = { 0 };
 	int len;
 	nsvg__xformIdentity(xform);
 	while (*str)


### PR DESCRIPTION
Silences -Wmaybe-uninitialized warnings from gcc-14